### PR TITLE
add newlines to rows

### DIFF
--- a/src/main/scala/com/gu/acquisitionFirehoseTransformer/Lambda.scala
+++ b/src/main/scala/com/gu/acquisitionFirehoseTransformer/Lambda.scala
@@ -23,7 +23,7 @@ object Lambda extends LazyLogging {
           None
         },
         (acquisition: Acquisition) => {
-          val jsonRow: String = AcquisitionToJson(acquisition, record.getApproximateArrivalTimestamp).noSpaces
+          val jsonRow: String = AcquisitionToJson(acquisition, record.getApproximateArrivalTimestamp).noSpaces +"\n"
 
           Some {
             new Record(record.getRecordId, Result.Ok, ByteBuffer.wrap(jsonRow.getBytes))


### PR DESCRIPTION
batches of events are currently being output on a single line when firehose writes to s3